### PR TITLE
Fix Github workflow test step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GOPROXY: "https://proxy.golang.org"
         run: |
+          go get -t pandora-pay/addresses
           go test -v ./addresses/.
           go test -v ./helpers/.
 


### PR DESCRIPTION
Fix the GitHub test step action to install required dependencies
Unfortunately, one test is KO in address_signatures_test.go:
```
        	Error Trace:	address_signatures_test.go:26
        	Error:      	Not equal: 
        	            	expected: false
        	            	actual  : true
        	Test:       	Test_VerifySignedMessage
        	Messages:   	verification failed
```
To be fixed eventually: I'm not sure how to fix this.